### PR TITLE
Avoid implicit perl imports - make them explicit.

### DIFF
--- a/www-spotify
+++ b/www-spotify
@@ -11,7 +11,7 @@ use warnings;
 
 use Data::Dumper::Compact qw(ddc);
 use Getopt::Long qw(GetOptions);
-use WWW::Spotify;
+use WWW::Spotify ();
 use YAML::XS qw(LoadFile);
 
 my %opts = (


### PR DESCRIPTION
See:

https://perl-begin.org/tutorials/bad-elements/#non_explicitly_imported_symbols .